### PR TITLE
Add device configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The `net4home` integration allows connections to more than one Bus connector. Fo
 - Binary sensors (contact, motion, etc.)
 - Localization support in English, German and Spanish
 - Add modules via the options flow (module type, software version, EE text and MI)
+- Add devices via the options flow (MI and module type)
 
 ## Installation
 

--- a/custom_components/net4home/__init__.py
+++ b/custom_components/net4home/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data.get("MI"),
             entry.data.get("OBJADR"),
             entry.entry_id,
-            # modules=entry.options.get("modules") if entry.options else None,
+            devices=entry.options.get("devices") if entry.options else None,
         )
         _LOGGER.debug("Net4HomeHub created")
         await hub.async_start()

--- a/custom_components/net4home/config_flow.py
+++ b/custom_components/net4home/config_flow.py
@@ -92,7 +92,18 @@ class Net4HomeOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_MI: user_input.get(CONF_MI),
                     CONF_OBJADR: user_input.get(CONF_OBJADR),
                 }
-                
+
+                options = dict(self.entry.options)
+                devices = options.get("devices", [])
+                device_mi = user_input.get("device_mi")
+                device_type = user_input.get("device_module_type")
+                if device_mi is not None and device_type:
+                    devices.append({"mi": device_mi, "module_type": device_type})
+                options["devices"] = devices
+
+                self.hass.config_entries.async_update_entry(
+                    self.entry, data=data, options=options
+                )
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_create_entry(title="", data={})
 
@@ -109,6 +120,8 @@ class Net4HomeOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional("software_version", default=""): str,
                 vol.Optional("ee_text", default=""): str,
                 vol.Optional("module_mi", default=0): int,
+                vol.Optional("device_module_type", default=""): str,
+                vol.Optional("device_mi", default=0): int,
             }
         )
 

--- a/custom_components/net4home/hub.py
+++ b/custom_components/net4home/hub.py
@@ -22,11 +22,15 @@ class Net4HomeDevice:
 class Net4HomeHub:
     """Manage a connection to a net4home server."""
 
-    def __init__(self, hass, host, port, password, mi, objadr, entry_id: str, modules=None):
+    def __init__(self, hass, host, port, password, mi, objadr, entry_id: str, devices=None):
         self.hass = hass
         self.entry_id = entry_id
         self.api = Net4HomeApi(hass, host, port, password, mi, objadr)
         self.devices: Dict[str, Net4HomeDevice] = {}
+
+        # Pre-register manually configured devices
+        for dev in devices or []:
+            self.register_device(str(dev.get("mi")), dev.get("module_type", ""))
 
     async def async_start(self):
         """Connect to the server and start listening."""

--- a/custom_components/net4home/translations/de.json
+++ b/custom_components/net4home/translations/de.json
@@ -35,7 +35,9 @@
           "module_type": "Modultyp",
           "software_version": "Software-Version",
           "ee_text": "EE-Text",
-          "module_mi": "Modul-MI"
+          "module_mi": "Modul-MI",
+          "device_module_type": "Gerätemodultyp",
+          "device_mi": "Geräte-MI"
         }
       }
     }

--- a/custom_components/net4home/translations/en.json
+++ b/custom_components/net4home/translations/en.json
@@ -35,7 +35,9 @@
           "module_type": "Module Type",
           "software_version": "Software Version",
           "ee_text": "EE Text",
-          "module_mi": "Module MI"
+          "module_mi": "Module MI",
+          "device_module_type": "Device Module Type",
+          "device_mi": "Device MI"
         }
       }
     }

--- a/custom_components/net4home/translations/es.json
+++ b/custom_components/net4home/translations/es.json
@@ -35,7 +35,9 @@
           "module_type": "Tipo de módulo",
           "software_version": "Versión de software",
           "ee_text": "Texto EE",
-          "module_mi": "MI del módulo"
+          "module_mi": "MI del módulo",
+          "device_module_type": "Tipo de módulo del dispositivo",
+          "device_mi": "MI del dispositivo"
         }
       }
     }


### PR DESCRIPTION
## Summary
- allow adding devices via options flow
- support storing configured devices in the hub
- mention device support in docs
- translate new device options

## Testing
- `python -m py_compile custom_components/net4home/*.py`